### PR TITLE
FOGL-8217 : Removed memory cleanup code as GTest takes care of it

### DIFF
--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -608,7 +608,7 @@ TEST(ASSET, assetsplit_1)
 	config->setValue("enable", "true");
 	ReadingSet *outReadings;
 	void *handle = plugin_init(config, &outReadings, Handler);
-	vector<Reading *> *readings = new vector<Reading *>;
+	vector<Reading *> readings;
 	long floor1 = 30;
 	long floor2 = 34;
 	DatapointValue dpv1(floor1);
@@ -616,8 +616,8 @@ TEST(ASSET, assetsplit_1)
 	std::vector<Datapoint *> dataPoints;
 	dataPoints.push_back(new Datapoint("Floor1", dpv1));
 	dataPoints.push_back(new Datapoint("Floor2", dpv2));
-	readings->push_back(new Reading("test", dataPoints));
-	ReadingSet *readingSet = new ReadingSet(readings);
+	readings.push_back(new Reading("test", dataPoints));
+	ReadingSet *readingSet = new ReadingSet(&readings);
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -633,11 +633,6 @@ TEST(ASSET, assetsplit_1)
 	ASSERT_EQ(results[1]->getAssetName(), "test_2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor1")->getName(), "Floor1");
 	ASSERT_EQ(results[1]->getDatapoint("Floor1")->getData().toInt(), 30);
-
-	//Memory cleanup
-	delete readings;
-	delete readingSet;
-
 }
 
 TEST(ASSET, assetsplit_2)
@@ -652,7 +647,7 @@ TEST(ASSET, assetsplit_2)
 	config->setValue("enable", "true");
 	ReadingSet *outReadings;
 	void *handle = plugin_init(config, &outReadings, Handler);
-	vector<Reading *> *readings = new vector<Reading *>;
+	vector<Reading *> readings;
 	long floor1 = 30;
 	long floor2 = 34;
 	DatapointValue dpv1(floor1);
@@ -660,8 +655,8 @@ TEST(ASSET, assetsplit_2)
 	std::vector<Datapoint *> dataPoints;
 	dataPoints.push_back(new Datapoint("Floor1", dpv1));
 	dataPoints.push_back(new Datapoint("Floor2", dpv2));
-	readings->push_back(new Reading("test", dataPoints));
-	ReadingSet *readingSet = new ReadingSet(readings);
+	readings.push_back(new Reading("test", dataPoints));
+	ReadingSet *readingSet = new ReadingSet(&readings);
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -675,10 +670,6 @@ TEST(ASSET, assetsplit_2)
 	ASSERT_EQ(results[1]->getAssetName(), "test_Floor2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor2")->getName(), "Floor2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor2")->getData().toInt(), 34);
-
-	//Memory cleanup
-	delete readings;
-	delete readingSet;
 }
 
 TEST(ASSET, assetsplit_3)
@@ -693,14 +684,14 @@ TEST(ASSET, assetsplit_3)
 	config->setValue("enable", "true");
 	ReadingSet *outReadings;
 	void *handle = plugin_init(config, &outReadings, Handler);
-	vector<Reading *> *readings = new vector<Reading *>;
+	vector<Reading *> readings;
 	long floor1 = 30;
 
 	DatapointValue dpv1(floor1);
 	std::vector<Datapoint *> dataPoints;
 	dataPoints.push_back(new Datapoint("Floor1", dpv1));
-	readings->push_back(new Reading("test", dataPoints));
-	ReadingSet *readingSet = new ReadingSet(readings);
+	readings.push_back(new Reading("test", dataPoints));
+	ReadingSet *readingSet = new ReadingSet(&readings);
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -709,9 +700,4 @@ TEST(ASSET, assetsplit_3)
 	ASSERT_EQ(results[0]->getAssetName(), "test_1");
 	ASSERT_EQ(results[0]->getDatapoint("Floor1")->getName(), "Floor1");
 	ASSERT_EQ(results[0]->getDatapoint("Floor1")->getData().toInt(), 30);
-
-	//Memory cleanup
-	delete readings;
-	delete readingSet;
-
 }


### PR DESCRIPTION
Test case result

```
Repeating all tests (iteration 200) . . .

Note: Randomizing tests' orders with a seed of 88817 .
[==========] Running 16 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from DELTA_INFO
[ RUN      ] DELTA_INFO.PluginInfoConfigParse
[       OK ] DELTA_INFO.PluginInfoConfigParse (0 ms)
[ RUN      ] DELTA_INFO.PluginInfo
[       OK ] DELTA_INFO.PluginInfo (0 ms)
[----------] 2 tests from DELTA_INFO (0 ms total)

[----------] 14 tests from ASSET
[ RUN      ] ASSET.remove
[       OK ] ASSET.remove (2 ms)
[ RUN      ] ASSET.rename
[       OK ] ASSET.rename (2 ms)
[ RUN      ] ASSET.flattenDatapointDictInsideDic
[       OK ] ASSET.flattenDatapointDictInsideDic (3 ms)
[ RUN      ] ASSET.remove_4
[       OK ] ASSET.remove_4 (2 ms)
[ RUN      ] ASSET.assetsplit_2
[       OK ] ASSET.assetsplit_2 (1 ms)
[ RUN      ] ASSET.remove_2
[       OK ] ASSET.remove_2 (1 ms)
[ RUN      ] ASSET.exclude
[       OK ] ASSET.exclude (2 ms)
[ RUN      ] ASSET.assetsplit_1
[       OK ] ASSET.assetsplit_1 (2 ms)
[ RUN      ] ASSET.flattenDatapointWithoutNesting
[       OK ] ASSET.flattenDatapointWithoutNesting (1 ms)
[ RUN      ] ASSET.include
[       OK ] ASSET.include (1 ms)
[ RUN      ] ASSET.assetsplit_3
[       OK ] ASSET.assetsplit_3 (1 ms)
[ RUN      ] ASSET.flattenDatapointDic
[       OK ] ASSET.flattenDatapointDic (2 ms)
[ RUN      ] ASSET.remove_3
[       OK ] ASSET.remove_3 (3 ms)
[ RUN      ] ASSET.datapointmap
[       OK ] ASSET.datapointmap (1 ms)
[----------] 14 tests from ASSET (32 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 2 test cases ran. (32 ms total)
[  PASSED  ] 16 tests.

```