### PR TITLE
FOGL-9559: Added check for missing rules item in config json

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -856,6 +856,13 @@ void plugin_reconfigure(PLUGIN_HANDLE *handle, const string& newConfig)
 			return;
 		}
 		
+		// Do not parse JSON further if rules array is not there.
+		if (!document.HasMember("rules"))
+		{
+			Logger::getLogger()->error("The asset filter configuration is missing the rules item : %s",filter->getConfig().getValue("config").c_str());
+			return;
+		}
+
 		newInfo->defaultAction = {action::INCLUDE, ""};
 		Value::MemberIterator defaultAction = document.FindMember("defaultAction");
 	    if(defaultAction == document.MemberEnd() || !defaultAction->value.IsString())


### PR DESCRIPTION
Unit Test Case
```
./RunTests
Note: Randomizing tests' orders with a seed of 63815 .
[==========] Running 43 tests from 5 test suites.
[----------] Global test environment set-up.
[----------] 16 tests from ASSET
[ RUN      ] ASSET.assetsplit_3
[       OK ] ASSET.assetsplit_3 (0 ms)
[ RUN      ] ASSET.remove_2
[       OK ] ASSET.remove_2 (1 ms)
[ RUN      ] ASSET.include
[       OK ] ASSET.include (0 ms)
[ RUN      ] ASSET.remove_4
[       OK ] ASSET.remove_4 (0 ms)
[ RUN      ] ASSET.datapointmap
[       OK ] ASSET.datapointmap (0 ms)
[ RUN      ] ASSET.assetsplit_2
[       OK ] ASSET.assetsplit_2 (0 ms)
[ RUN      ] ASSET.flattenDatapointDic
[       OK ] ASSET.flattenDatapointDic (0 ms)
[ RUN      ] ASSET.select_missing
[       OK ] ASSET.select_missing (0 ms)
[ RUN      ] ASSET.assetsplit_1
[       OK ] ASSET.assetsplit_1 (0 ms)
[ RUN      ] ASSET.flattenDatapointDictInsideDic
[       OK ] ASSET.flattenDatapointDictInsideDic (0 ms)
[ RUN      ] ASSET.rename
[       OK ] ASSET.rename (0 ms)
[ RUN      ] ASSET.remove
[       OK ] ASSET.remove (0 ms)
[ RUN      ] ASSET.flattenDatapointWithoutNesting
[       OK ] ASSET.flattenDatapointWithoutNesting (1 ms)
[ RUN      ] ASSET.select
[       OK ] ASSET.select (0 ms)
[ RUN      ] ASSET.remove_3
[       OK ] ASSET.remove_3 (0 ms)
[ RUN      ] ASSET.exclude
[       OK ] ASSET.exclude (0 ms)
[----------] 16 tests from ASSET (2 ms total)

[----------] 5 tests from ASSET_MULTIPLE_RULE
[ RUN      ] ASSET_MULTIPLE_RULE.RenameAfterExclude
[       OK ] ASSET_MULTIPLE_RULE.RenameAfterExclude (0 ms)
[ RUN      ] ASSET_MULTIPLE_RULE.RenameDatapointUsingOldAsset
[       OK ] ASSET_MULTIPLE_RULE.RenameDatapointUsingOldAsset (0 ms)
[ RUN      ] ASSET_MULTIPLE_RULE.RemoveTwoDPs
[       OK ] ASSET_MULTIPLE_RULE.RemoveTwoDPs (0 ms)
[ RUN      ] ASSET_MULTIPLE_RULE.RenameDatapointUsingNewAsset
[       OK ] ASSET_MULTIPLE_RULE.RenameDatapointUsingNewAsset (0 ms)
[ RUN      ] ASSET_MULTIPLE_RULE.ExcludeSplittedAsset
[       OK ] ASSET_MULTIPLE_RULE.ExcludeSplittedAsset (0 ms)
[----------] 5 tests from ASSET_MULTIPLE_RULE (0 ms total)

[----------] 2 tests from ASSET_INFO
[ RUN      ] ASSET_INFO.PluginInfoConfigParse
[       OK ] ASSET_INFO.PluginInfoConfigParse (0 ms)
[ RUN      ] ASSET_INFO.PluginInfo
[       OK ] ASSET_INFO.PluginInfo (0 ms)
[----------] 2 tests from ASSET_INFO (0 ms total)

[----------] 14 tests from ASSET_BAD_CONFIG
[ RUN      ] ASSET_BAD_CONFIG.SelectAssets
[       OK ] ASSET_BAD_CONFIG.SelectAssets (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.BadAction
[       OK ] ASSET_BAD_CONFIG.BadAction (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.NoRules
[       OK ] ASSET_BAD_CONFIG.NoRules (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.RemoveMissing
[       OK ] ASSET_BAD_CONFIG.RemoveMissing (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.MissingAsset
[       OK ] ASSET_BAD_CONFIG.MissingAsset (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.SplitNotObject
[       OK ] ASSET_BAD_CONFIG.SplitNotObject (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.RenameNoNewName
[       OK ] ASSET_BAD_CONFIG.RenameNoNewName (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.MissingAction
[       OK ] ASSET_BAD_CONFIG.MissingAction (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.BadDefaultAction
[       OK ] ASSET_BAD_CONFIG.BadDefaultAction (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.MissingRulesItem
[       OK ] ASSET_BAD_CONFIG.MissingRulesItem (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.BadRule
[       OK ] ASSET_BAD_CONFIG.BadRule (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.SplitNotList
[       OK ] ASSET_BAD_CONFIG.SplitNotList (1 ms)
[ RUN      ] ASSET_BAD_CONFIG.SplitListType
[       OK ] ASSET_BAD_CONFIG.SplitListType (0 ms)
[ RUN      ] ASSET_BAD_CONFIG.DatapointMapMissing
[       OK ] ASSET_BAD_CONFIG.DatapointMapMissing (0 ms)
[----------] 14 tests from ASSET_BAD_CONFIG (2 ms total)

[----------] 6 tests from ASSET_REGEX
[ RUN      ] ASSET_REGEX.remove
[       OK ] ASSET_REGEX.remove (0 ms)
[ RUN      ] ASSET_REGEX.include
[       OK ] ASSET_REGEX.include (1 ms)
[ RUN      ] ASSET_REGEX.rename
[       OK ] ASSET_REGEX.rename (0 ms)
[ RUN      ] ASSET_REGEX.remove2
[       OK ] ASSET_REGEX.remove2 (0 ms)
[ RUN      ] ASSET_REGEX.exclude
[       OK ] ASSET_REGEX.exclude (0 ms)
[ RUN      ] ASSET_REGEX.datapointmap
[       OK ] ASSET_REGEX.datapointmap (0 ms)
[----------] 6 tests from ASSET_REGEX (1 ms total)

[----------] Global test environment tear-down
[==========] 43 tests from 5 test suites ran. (5 ms total)
[  PASSED  ] 43 tests.

```