### PR TITLE
FOGL-9686 Fix memory leaks in unit tests and in the filter itself

### DIFF
--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -19,6 +19,7 @@ extern "C" {
 	PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 			  OUTPUT_HANDLE *outHandle,
 			  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 	int called = 0;
 
 	void Handler(void *handle, READINGSET *readings)
@@ -79,6 +80,7 @@ TEST(ASSET, exclude)
 	readings->push_back(new Reading("test1", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
@@ -92,6 +94,10 @@ TEST(ASSET, exclude)
 	ASSERT_STREQ(outdp->getName().c_str(), "test");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 
 }
 
@@ -124,6 +130,7 @@ TEST(ASSET, include)
 	readings->push_back(new Reading("test1", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 
@@ -139,6 +146,9 @@ TEST(ASSET, include)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, rename)
@@ -170,6 +180,7 @@ TEST(ASSET, rename)
 	readings->push_back(new Reading("test1", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 
@@ -205,6 +216,9 @@ TEST(ASSET, rename)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, datapointmap)
@@ -236,6 +250,7 @@ TEST(ASSET, datapointmap)
 	readings->push_back(new Reading("test1", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 
@@ -271,6 +286,9 @@ TEST(ASSET, datapointmap)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, remove)
@@ -302,6 +320,7 @@ TEST(ASSET, remove)
         readings->push_back(new Reading("test", value2));
 
         ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
         plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
@@ -332,6 +351,9 @@ TEST(ASSET, remove)
         points = out->getReadingData();
         ASSERT_EQ(points.size(), 0);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 TEST(ASSET, remove_2)
 {
@@ -362,6 +384,7 @@ TEST(ASSET, remove_2)
         readings->push_back(new Reading("test", value2));
 
         ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
         plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
@@ -384,6 +407,9 @@ TEST(ASSET, remove_2)
         points = out->getReadingData();
         ASSERT_EQ(points.size(), 0);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, remove_3)
@@ -415,6 +441,7 @@ TEST(ASSET, remove_3)
         readings->push_back(new Reading("test", value2));
 
         ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
         plugin_ingest(handle, (READINGSET *)readingSet);
 
         vector<Reading *>results = outReadings->getAllReadings();
@@ -435,6 +462,10 @@ TEST(ASSET, remove_3)
         ASSERT_STREQ(out->getAssetName().c_str(), "test");
         ASSERT_EQ(out->getDatapointCount(), 0);
         points = out->getReadingData();
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, remove_4)
@@ -466,6 +497,7 @@ TEST(ASSET, remove_4)
         readings->push_back(new Reading("test", value2));
 
         ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
         plugin_ingest(handle, (READINGSET *)readingSet);
 
         vector<Reading *>results = outReadings->getAllReadings();
@@ -480,8 +512,6 @@ TEST(ASSET, remove_4)
         ASSERT_STREQ(outdp->getName().c_str(), "test");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
         ASSERT_EQ(outdp->getData().toInt(), 1000);
-
-
 
         out = results[1];
         ASSERT_STREQ(out->getAssetName().c_str(), "test");
@@ -503,6 +533,9 @@ TEST(ASSET, remove_4)
  	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
         ASSERT_EQ(outdp->getData().toInt(), 1140);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, flattenDatapointWithoutNesting)
@@ -525,12 +558,17 @@ TEST(ASSET, flattenDatapointWithoutNesting)
 	readings->push_back(new Reading("test", NestedReadingJSON));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);
 	ASSERT_EQ(results[0]->getAssetName(), "test");
 	ASSERT_EQ(results[0]->getDatapoint("pressure")->getName(), "pressure");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, flattenDatapointDic)
@@ -553,6 +591,7 @@ TEST(ASSET, flattenDatapointDic)
 	readings->push_back(new Reading("test", NestedReadingJSON));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -562,6 +601,10 @@ TEST(ASSET, flattenDatapointDic)
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor1")->getName(), "pressure_floor1");
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor2")->getName(), "pressure_floor2");
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor3")->getName(), "pressure_floor3");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, flattenDatapointDictInsideDic)
@@ -584,6 +627,7 @@ TEST(ASSET, flattenDatapointDictInsideDic)
 	readings->push_back(new Reading("test", NestedReadingJSON));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -595,6 +639,10 @@ TEST(ASSET, flattenDatapointDictInsideDic)
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor3_room1")->getName(), "pressure_floor3_room1");
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor3_room2")->getName(), "pressure_floor3_room2");
 	ASSERT_EQ(results[0]->getDatapoint("pressure_floor3_room3")->getName(), "pressure_floor3_room3");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, assetsplit_1)
@@ -634,6 +682,10 @@ TEST(ASSET, assetsplit_1)
 	ASSERT_EQ(results[1]->getAssetName(), "test_2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor1")->getName(), "Floor1");
 	ASSERT_EQ(results[1]->getDatapoint("Floor1")->getData().toInt(), 30);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, assetsplit_2)
@@ -671,6 +723,10 @@ TEST(ASSET, assetsplit_2)
 	ASSERT_EQ(results[1]->getAssetName(), "test_Floor2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor2")->getName(), "Floor2");
 	ASSERT_EQ(results[1]->getDatapoint("Floor2")->getData().toInt(), 34);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, assetsplit_3)
@@ -701,6 +757,10 @@ TEST(ASSET, assetsplit_3)
 	ASSERT_EQ(results[0]->getAssetName(), "test_1");
 	ASSERT_EQ(results[0]->getDatapoint("Floor1")->getName(), "Floor1");
 	ASSERT_EQ(results[0]->getDatapoint("Floor1")->getData().toInt(), 30);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, select)
@@ -742,6 +802,10 @@ TEST(ASSET, select)
 	ASSERT_EQ(results[0]->getDatapoint("current")->getName(), "current");
 	ASSERT_EQ(results[0]->getDatapoint("current")->getData().toDouble(), 0.12);
 	ASSERT_EQ(results[0]->getDatapoint("current")->getData().getTypeStr(), "FLOAT");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 TEST(ASSET, select_missing)
@@ -780,4 +844,8 @@ TEST(ASSET, select_missing)
 	ASSERT_EQ(results[0]->getDatapoint("voltage")->getName(), "voltage");
 	ASSERT_EQ(results[0]->getDatapoint("voltage")->getData().toInt(), 30);
 	ASSERT_EQ(results[0]->getDatapoint("voltage")->getData().getTypeStr(), "INTEGER");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }

--- a/tests/test_badconfig.cpp
+++ b/tests/test_badconfig.cpp
@@ -26,6 +26,7 @@ extern "C"
 	PLUGIN_HANDLE plugin_init(ConfigCategory *config,
 							  OUTPUT_HANDLE *outHandle,
 							  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 
 	void plugin_reconfigure(void *handle, const string& newConfig);
 
@@ -83,10 +84,15 @@ TEST(ASSET_BAD_CONFIG, BadDefaultAction)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the handling of a bad (non object) rule
@@ -109,10 +115,15 @@ TEST(ASSET_BAD_CONFIG, BadRule)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the handling of a configuration without any rules
@@ -135,10 +146,15 @@ TEST(ASSET_BAD_CONFIG, NoRules)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the reconfiguration without rules item in JSON
@@ -161,6 +177,7 @@ TEST(ASSET_BAD_CONFIG, MissingRulesItem)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -178,6 +195,19 @@ TEST(ASSET_BAD_CONFIG, MissingRulesItem)
 	{
 		ASSERT_STREQ(e.what(), "Configuration category JSON is malformed");
 	}
+	delete outReadings;
+
+	// Recreate the readings as the original RadingSet has
+	// been freed by the previous plugin_ingest
+	readings = new vector<Reading *>;
+
+	testValue = 1000;
+	DatapointValue dpv2(testValue);
+	value = new Datapoint("P1", dpv2);
+	readings->push_back(new Reading("Pressure", value));
+
+	readingSet = new ReadingSet(readings);
+	delete readings;
 
 	// Ingest after reconfigure
 	plugin_ingest(handle, (READINGSET *)readingSet);
@@ -187,6 +217,10 @@ TEST(ASSET_BAD_CONFIG, MissingRulesItem)
 	Reading *out1 = results1[0];
 	// Asset name changed because new filter action is ignored due to bad config after reconfigure
 	ASSERT_STREQ(out1->getAssetName().c_str(), "Vibration");
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the handling of a configuration with a ruel that has an unsupported action
@@ -209,10 +243,15 @@ TEST(ASSET_BAD_CONFIG, BadAction)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the handling of a configuration a rule with a missing action
@@ -235,10 +274,15 @@ TEST(ASSET_BAD_CONFIG, MissingAction)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test the handling of a configuration without an asset in the rule
@@ -261,13 +305,18 @@ TEST(ASSET_BAD_CONFIG, MissingAsset)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
-// Test handlign of misonfigured rename action
+// Test handling of misconfigured rename action
 TEST(ASSET_BAD_CONFIG, RenameNoNewName)
 {
 	PLUGIN_INFORMATION *info = plugin_info();
@@ -287,10 +336,15 @@ TEST(ASSET_BAD_CONFIG, RenameNoNewName)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured select action
@@ -313,10 +367,15 @@ TEST(ASSET_BAD_CONFIG, SelectAssets)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured datapoiimntmap action
@@ -339,10 +398,15 @@ TEST(ASSET_BAD_CONFIG, DatapointMapMissing)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured remove action
@@ -365,10 +429,15 @@ TEST(ASSET_BAD_CONFIG, RemoveMissing)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured split action, the value of the split attribute is not an object
@@ -391,10 +460,15 @@ TEST(ASSET_BAD_CONFIG, SplitNotObject)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured split action, the value of the split asset is not an list
@@ -417,10 +491,15 @@ TEST(ASSET_BAD_CONFIG, SplitNotList)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test handling of misconfigured split action, the value of the datapoitn naem is not a string
@@ -443,8 +522,13 @@ TEST(ASSET_BAD_CONFIG, SplitListType)
 	readings->push_back(new Reading("Pressure", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);  
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }

--- a/tests/test_multiple.cpp
+++ b/tests/test_multiple.cpp
@@ -20,6 +20,7 @@ extern "C"
 	PLUGIN_HANDLE plugin_init(ConfigCategory *config,
 							  OUTPUT_HANDLE *outHandle,
 							  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 
 	extern void Handler(void *handle, READINGSET *readings);
 };
@@ -60,6 +61,7 @@ TEST(ASSET_MULTIPLE_RULE, RemoveTwoDPs)
 	readings->push_back(new Reading("test", dpVec));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
@@ -73,6 +75,10 @@ TEST(ASSET_MULTIPLE_RULE, RemoveTwoDPs)
 	ASSERT_STREQ(outdp->getName().c_str(), "DP2");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1001);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test Multiple Rules on same asset - Rename an asset after excluding it
@@ -95,10 +101,15 @@ TEST(ASSET_MULTIPLE_RULE, RenameAfterExclude)
 	readings->push_back(new Reading("test", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 0); // No further action can be performed on the excluded PR
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test Multiple Rules on same asset - Exclude one of the splitted asset
@@ -134,6 +145,7 @@ TEST(ASSET_MULTIPLE_RULE, ExcludeSplittedAsset)
 	readings->push_back(new Reading("test", dpVec));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
@@ -152,6 +164,10 @@ TEST(ASSET_MULTIPLE_RULE, ExcludeSplittedAsset)
 	ASSERT_STREQ(outdp->getName().c_str(), "DP4");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1500);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test Multiple Rules on same asset - 1. Rename an asset, 2. Rename datapoint using old asset name
@@ -174,12 +190,17 @@ TEST(ASSET_MULTIPLE_RULE, RenameDatapointUsingOldAsset)
 	readings->push_back(new Reading("test", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);
 	ASSERT_STREQ(results[0]->getAssetName().c_str(), "NewAsset"); // Asset name changed from test to NewAsset
 	ASSERT_STREQ((results[0]->getReadingData()[0])->getName().c_str(), "test"); // Datapoint name didn't change using old asset
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Test Multiple Rules on same asset - 1. Rename an asset, 2. Rename datapoint using new asset name
@@ -202,11 +223,16 @@ TEST(ASSET_MULTIPLE_RULE, RenameDatapointUsingNewAsset)
 	readings->push_back(new Reading("test", value));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *>results = outReadings->getAllReadings();
 	ASSERT_EQ(results.size(), 1);
 	ASSERT_STREQ(results[0]->getAssetName().c_str(), "NewAsset"); // Asset name changed from test to NewAsset
 	ASSERT_STREQ((results[0]->getReadingData()[0])->getName().c_str(), "NewDP"); // Datapoint name changed using new asset
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 

--- a/tests/test_regex.cpp
+++ b/tests/test_regex.cpp
@@ -20,6 +20,7 @@ extern "C"
 	PLUGIN_HANDLE plugin_init(ConfigCategory *config,
 							  OUTPUT_HANDLE *outHandle,
 							  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 
 	extern void Handler(void *handle, READINGSET *readings);
 };
@@ -62,12 +63,16 @@ TEST(ASSET_REGEX, exclude)
 	readings->push_back(new Reading("PressurePump", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
 	// asset_name = "Pressure.*" in rule matches both the assets Pressure and PressurePump. So both the assets have been excluded
 	ASSERT_EQ(results.size(), 0);  
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Regular expression checked for
@@ -101,6 +106,7 @@ TEST(ASSET_REGEX, include)
 	readings->push_back(new Reading("Camera_1", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -115,6 +121,10 @@ TEST(ASSET_REGEX, include)
 	ASSERT_STREQ(outdp->getName().c_str(), "Floor1_Feed");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Regular expression checked for
@@ -148,6 +158,7 @@ TEST(ASSET_REGEX, rename)
 	readings->push_back(new Reading("PressureTank", value2));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -181,6 +192,10 @@ TEST(ASSET_REGEX, rename)
 	ASSERT_STREQ(outdp->getName().c_str(), "temperature");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Regular expression checked for
@@ -209,6 +224,7 @@ TEST(ASSET_REGEX, datapointmap)
 	readings->push_back(new Reading("Camera_site1", value1));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -236,6 +252,9 @@ TEST(ASSET_REGEX, datapointmap)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1001);
 
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Regular expression checked for
@@ -271,6 +290,7 @@ TEST(ASSET_REGEX, remove)
 	readings->push_back(new Reading("Humidity", value3));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -296,6 +316,9 @@ TEST(ASSET_REGEX, remove)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1140);
 	
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }
 
 // Regular expression checked for
@@ -339,6 +362,7 @@ TEST(ASSET_REGEX, remove2)
 	readings->push_back(new Reading("Humidity", dpVec1));
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -368,4 +392,8 @@ TEST(ASSET_REGEX, remove2)
 	ASSERT_STREQ(outdp->getName().c_str(), "value");
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 1200);
+
+	delete outReadings;
+	plugin_shutdown(handle);
+	delete config;
 }


### PR DESCRIPTION
==3269144== 
==3269144== HEAP SUMMARY:
==3269144==     in use at exit: 40 bytes in 1 blocks
==3269144==   total heap usage: 1,541,502 allocs, 1,541,501 frees, 1,873,611,195 bytes allocated
==3269144== 
==3269144== LEAK SUMMARY:
==3269144==    definitely lost: 0 bytes in 0 blocks
==3269144==    indirectly lost: 0 bytes in 0 blocks
==3269144==      possibly lost: 0 bytes in 0 blocks
==3269144==    still reachable: 40 bytes in 1 blocks
==3269144==         suppressed: 0 bytes in 0 blocks
==3269144== Reachable blocks (those to which a pointer was found) are not shown.
==3269144== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3269144== 
==3269144== For lists of detected and suppressed errors, rerun with: -s
==3269144== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)